### PR TITLE
Update cors proxy

### DIFF
--- a/js/creator-10.js
+++ b/js/creator-10.js
@@ -1378,7 +1378,7 @@ function loadTutorialVideo() {
 function imageURL(url, destination, otherParams) {
 	var imageurl = url;
 	if (params.get('noproxy') != '') {
-		imageurl = 'https://cors-anywhere.herokuapp.com/' + url;
+		imageurl = 'https://cors.bridged.cc/' + url;
 	}
 	destination(imageurl, otherParams);
 }


### PR DESCRIPTION
cors-anywhere has been greatly limited (see https://github.com/Rob--W/cors-anywhere/issues/301), and as such breaks image fetching. Replacing it with a more public cors proxy.